### PR TITLE
fix(PS2): add periodic call to /investments

### DIFF
--- a/packages/ps2/src/components/Navigation/BalanceButton/index.tsx
+++ b/packages/ps2/src/components/Navigation/BalanceButton/index.tsx
@@ -13,16 +13,20 @@ import { useZModal } from 'components/ZModal/use';
 import DepositModal from 'views/Dashboard/components/ManageInvestmentModals/DepositModal';
 import { GradientBorderButtonWrapper } from '../ReferralButton/atoms';
 
+const UPDATE_INTERVAL = 60 * 1000;
+
 const BalanceButton = () => {
   const { t } = useTranslation('common');
   const { internalId } = useActiveExchange();
-  const { data: investments } = useInvestmentsQuery(internalId);
+  const { data: investments } = useInvestmentsQuery(internalId, {
+    pollingInterval: UPDATE_INTERVAL,
+  });
   const { data: balance } = useBalanceQuery(
     {
       exchangeInternalId: internalId,
     },
     {
-      pollingInterval: 60 * 1000,
+      pollingInterval: UPDATE_INTERVAL,
     },
   );
   const { showModal } = useZModal();


### PR DESCRIPTION
To avoid having an updated available balance (also periodically updated), but not the investments, adding discrepancies between available and total amounts.
I guess this also partially solves the issue where the user navigates to the portfolio, but no network call is made, and the data is always fetched from the cache. We can't use keepUnusedDataFor because it's only when there are no more subscribers. Which will never happen since the top widget is always shown, except when logging out. See https://redux-toolkit.js.org/rtk-query/api/createApi#keepunuseddatafor