### PR TITLE
fix(PS2): replace margin with padding

### DIFF
--- a/packages/ps2/src/components/Navigation/ExtraNavigationDropdown/styles.ts
+++ b/packages/ps2/src/components/Navigation/ExtraNavigationDropdown/styles.ts
@@ -72,7 +72,7 @@ export const Networks = styled('div')`
   gap: 16px;
   background: rgb(28, 29, 53);
   padding: 19px 32px;
-  margin: 6px -32px -12px;
+  margin: 6px -32px -6px;
 
   > a {
     line-height: 0;

--- a/packages/zignaly-ui/src/components/display/ZigDropdown/styles.ts
+++ b/packages/zignaly-ui/src/components/display/ZigDropdown/styles.ts
@@ -117,7 +117,7 @@ export const NavList = styled.div`
     margin-top: 11px;
   }
   > *:last-child {
-    margin-bottom: 6px;
+    padding-bottom: 6px;
   }
 `;
 


### PR DESCRIPTION
To keep the background color of the expanded menu until the bottom of the dropdown