### PR TITLE
fix(PS2): fix text alignment

### DIFF
--- a/packages/zignaly-ui/src/components/filters/ZigFilters/dropdowns/atoms/FilterCount/index.tsx
+++ b/packages/zignaly-ui/src/components/filters/ZigFilters/dropdowns/atoms/FilterCount/index.tsx
@@ -12,4 +12,7 @@ export const FiltersCount = styled(ZigTypography)`
   font-weight: 600;
   font-size: 12px;
   border-radius: 50%;
+  /* font fix... */
+  padding-left: 1px;
+  padding-top: 1px;
 `;


### PR DESCRIPTION
This font is a total nightmare to center, I don’t think those hacks are a proper long term solution…