### PR TITLE
feat(PS2): override images color

### DIFF
--- a/packages/ps2/src/views/TraderService/components/BecomeTraderLanding/index.tsx
+++ b/packages/ps2/src/views/TraderService/components/BecomeTraderLanding/index.tsx
@@ -1,6 +1,11 @@
 import React, { useMemo } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
-import { ZigButton, ZigLink, ZigTypography } from '@zignaly-open/ui';
+import {
+  ZigButton,
+  ZigImageColorOverride,
+  ZigLink,
+  ZigTypography,
+} from '@zignaly-open/ui';
 import {
   Layout,
   Header,
@@ -19,11 +24,9 @@ import {
   Section,
   FeaturesList,
   Feature,
-  FeatureImage,
   FeatureData,
   StepList,
   Step,
-  StepImage,
   Box,
   Separator,
 } from './styles';
@@ -246,9 +249,11 @@ const BecomeTraderLanding: React.FC = () => {
                       >
                         {howWorkItem.title.toUpperCase()}
                       </ZigTypography>
-                      <StepImage
+                      <ZigImageColorOverride
+                        width={300}
+                        height={150}
+                        href={'/images/service-provider/' + howWorkItem.image}
                         id={howWorkItem.id && `${howWorkItem.id}-image`}
-                        src={'/images/service-provider/' + howWorkItem.image}
                       />
                     </Center>
                     <ZigTypography
@@ -278,9 +283,11 @@ const BecomeTraderLanding: React.FC = () => {
           <FeaturesList itemsLength={featuresItems.length}>
             {featuresItems.map((feature, index) => (
               <Feature key={`--features-item-${index.toString()}`}>
-                <FeatureImage
+                <ZigImageColorOverride
+                  width={80}
+                  height={80}
+                  href={'/images/service-provider/' + feature.image}
                   id={feature.id && `${feature.id}-image`}
-                  src={'/images/service-provider/' + feature.image}
                 />
                 <FeatureData>
                   <ZigTypography

--- a/packages/ps2/src/views/TraderService/components/BecomeTraderLanding/index.tsx
+++ b/packages/ps2/src/views/TraderService/components/BecomeTraderLanding/index.tsx
@@ -250,7 +250,7 @@ const BecomeTraderLanding: React.FC = () => {
                         {howWorkItem.title.toUpperCase()}
                       </ZigTypography>
                       <ZigImageColorOverride
-                        width={307}
+                        width={306}
                         height={120}
                         href={'/images/service-provider/' + howWorkItem.image}
                         id={howWorkItem.id && `${howWorkItem.id}-image`}

--- a/packages/ps2/src/views/TraderService/components/BecomeTraderLanding/index.tsx
+++ b/packages/ps2/src/views/TraderService/components/BecomeTraderLanding/index.tsx
@@ -254,6 +254,7 @@ const BecomeTraderLanding: React.FC = () => {
                         height={150}
                         href={'/images/service-provider/' + howWorkItem.image}
                         id={howWorkItem.id && `${howWorkItem.id}-image`}
+                        style={{ margin: '24px 0' }}
                       />
                     </Center>
                     <ZigTypography

--- a/packages/ps2/src/views/TraderService/components/BecomeTraderLanding/index.tsx
+++ b/packages/ps2/src/views/TraderService/components/BecomeTraderLanding/index.tsx
@@ -250,8 +250,8 @@ const BecomeTraderLanding: React.FC = () => {
                         {howWorkItem.title.toUpperCase()}
                       </ZigTypography>
                       <ZigImageColorOverride
-                        width={300}
-                        height={150}
+                        width={307}
+                        height={120}
                         href={'/images/service-provider/' + howWorkItem.image}
                         id={howWorkItem.id && `${howWorkItem.id}-image`}
                         style={{ margin: '24px 0' }}

--- a/packages/ps2/src/views/TraderService/components/BecomeTraderLanding/styles.ts
+++ b/packages/ps2/src/views/TraderService/components/BecomeTraderLanding/styles.ts
@@ -113,11 +113,6 @@ export const Feature = styled.li`
   gap: 22px;
 `;
 
-export const FeatureImage = styled.img`
-  width: 80px;
-  height: 80px;
-`;
-
 export const FeatureData = styled.div`
   display: flex;
   flex-direction: column;
@@ -144,13 +139,6 @@ export const Box = styled.div`
   background-color: ${({ theme }) => theme.palette.neutral750};
   border-radius: 4px;
   width: 100%;
-`;
-
-export const StepImage = styled.img`
-  margin: 24px 0;
-  width: 100%;
-  object-fit: contain;
-  height: 120px;
 `;
 
 export const Separator = styled.li`

--- a/packages/zignaly-ui/src/components/display/ZigImageColorOverride/index.tsx
+++ b/packages/zignaly-ui/src/components/display/ZigImageColorOverride/index.tsx
@@ -23,7 +23,7 @@ const ZigImageColorOverride = ({ width, height, id, ...rest }: React.SVGProps<SV
       <image
         width="100%"
         height="100%"
-        filter={theme.palette.imageColorOverride ? "url(#imageColorOverride)" : null}
+        filter={theme.palette.imageColorOverride ? "url(#imageColorOverride)" : undefined}
         {...rest}
       />
     </svg>

--- a/packages/zignaly-ui/src/components/display/ZigImageColorOverride/index.tsx
+++ b/packages/zignaly-ui/src/components/display/ZigImageColorOverride/index.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { useTheme } from "@mui/material";
+
+const ZigImageColorOverride = ({ width, height, id, ...rest }: React.SVGProps<SVGImageElement>) => {
+  const theme = useTheme();
+  return (
+    <svg width={width} height={height} id={id && id}>
+      <defs>
+        <filter id="imageColorOverride">
+          <feFlood flood-color={theme.palette.imageColorOverride} result="flood" />
+          <feComposite
+            in="SourceGraphic"
+            in2="flood"
+            operator="arithmetic"
+            k1="1"
+            k2="0"
+            k3="0"
+            k4="0"
+          />
+        </filter>
+      </defs>
+
+      <image
+        width="100%"
+        height="100%"
+        filter={theme.palette.imageColorOverride ? "url(#imageColorOverride)" : null}
+        {...rest}
+      />
+    </svg>
+  );
+};
+
+export default ZigImageColorOverride;

--- a/packages/zignaly-ui/src/components/display/ZigImageColorOverride/index.tsx
+++ b/packages/zignaly-ui/src/components/display/ZigImageColorOverride/index.tsx
@@ -1,10 +1,16 @@
 import React from "react";
 import { useTheme } from "@mui/material";
 
-const ZigImageColorOverride = ({ width, height, id, ...rest }: React.SVGProps<SVGImageElement>) => {
+const ZigImageColorOverride = ({
+  width,
+  height,
+  id,
+  style,
+  ...rest
+}: React.SVGProps<SVGImageElement>) => {
   const theme = useTheme();
   return (
-    <svg width={width} height={height} id={id && id}>
+    <svg width={width} height={height} id={id && id} style={style}>
       <defs>
         <filter id="imageColorOverride">
           <feFlood flood-color={theme.palette.imageColorOverride} result="flood" />

--- a/packages/zignaly-ui/src/index.ts
+++ b/packages/zignaly-ui/src/index.ts
@@ -60,6 +60,7 @@ export { default as ZScoreRing } from "./components/display/ZScoreRing";
 export * from "./components/display/ZScoreRing";
 export { default as ZScoreRings } from "./components/display/ZScoreRings";
 export { default as ZScoreBar } from "./components/display/ZScoreBar";
+export { default as ZigImageColorOverride } from "./components/display/ZigImageColorOverride";
 
 // Table
 export { createColumnHelper } from "@tanstack/react-table";

--- a/packages/zignaly-ui/src/module-name.d.ts
+++ b/packages/zignaly-ui/src/module-name.d.ts
@@ -74,6 +74,8 @@ declare module "@mui/material/styles" {
       Record<"red" | "green", string>;
 
     zscore: ZScoreTheme;
+
+    imageColorOverride?: string;
   }
 
   type RingTheme = {

--- a/packages/zignaly-ui/src/theme/muiTheme.ts
+++ b/packages/zignaly-ui/src/theme/muiTheme.ts
@@ -17,6 +17,7 @@ const createMuiTheme = ({
   boxShadows,
   fontFamily,
   fontFamilyH1H6,
+  imageColorOverride,
 }: ThemeStyledComponents) =>
   createTheme({
     palette: {
@@ -40,6 +41,7 @@ const createMuiTheme = ({
       boxShadows,
       chart,
       zscore,
+      imageColorOverride,
     },
     typography: {
       fontFamily: fontFamily.join(","),

--- a/packages/zignaly-ui/src/theme/themes/dark.ts
+++ b/packages/zignaly-ui/src/theme/themes/dark.ts
@@ -109,6 +109,7 @@ const dark: ThemeStyledComponents = {
       balanced: "linear-gradient(to right, #10341d, #46995c 42%, #76dd88 76%, #88c489)",
     },
   },
+  imageColorOverride: undefined,
 };
 
 export default dark;

--- a/packages/zignaly-ui/src/theme/types.ts
+++ b/packages/zignaly-ui/src/theme/types.ts
@@ -40,6 +40,7 @@ export type ThemeStyledComponents = {
   chart: CustomPalette["chart"];
   zscore: CustomPalette["zscore"];
   mode: "dark" | "light";
+  imageColorOverride?: string;
 };
 
 // https://stackoverflow.com/a/61132308/2044039


### PR DESCRIPTION
To turn
<img width="1396" alt="image" src="https://github.com/zignaly-open/zignaly-neo/assets/5314435/65d3a574-91da-403d-8a86-f5a3be7f2a86">

into
<img width="1386" alt="image" src="https://github.com/zignaly-open/zignaly-neo/assets/5314435/3fb345be-4116-45cb-91ff-ea4bc8c0643e">

Not a big fan of this approach, as it doesn’t handle turning white strokes into dark strokes for example, if the new color had to be white.

Also css filters were unfortunately not enough compared to svg filters.